### PR TITLE
Ignore white space in rule mode, do not create a selector.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -104,6 +104,7 @@ function parse(tokens) {
 
 		case "rule":
 			switch(token.tokenType) {
+			case "WHITESPACE": break;
 			case "BADSTRING":
 			case "BADURL": parseerror() && switchto('next-block'); break;
 			case "}": pop() && switchto(); break;


### PR DESCRIPTION
Test case:

```
@media{ }
```

The same bug exists in the spec:
http://lists.w3.org/Archives/Public/www-style/2012Jul/0345.html
