### PR TITLE
Line information + UMD

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1,3 +1,15 @@
+(function (root, factory) {
+    // Universal Module Definition (UMD) to support AMD, CommonJS/Node.js,
+    // Rhino, and plain browser loading.
+    if (typeof define === 'function' && define.amd) {
+        define(['exports'], factory);
+    } else if (typeof exports !== 'undefined') {
+        factory(exports);
+    } else {
+        factory(root);
+    }
+}(this, function (exports) {
+
 function parse(tokens) {
 	var mode = 'top-level';
 	var i = -1;
@@ -339,8 +351,8 @@ FuncArg.prototype.toJSON = function() {
 	return this.value.map(function(e){return e.toJSON();});
 }
 
-// Make this usable from NodeJS
+// Exportation.
 // TODO: also export the various rule objects?
-if (typeof(exports) != 'undefined') {
-    exports.parse = parse;
-}
+exports.parse = parse;
+
+}));

--- a/tokenizer.js
+++ b/tokenizer.js
@@ -1,3 +1,15 @@
+(function (root, factory) {
+    // Universal Module Definition (UMD) to support AMD, CommonJS/Node.js,
+    // Rhino, and plain browser loading.
+    if (typeof define === 'function' && define.amd) {
+        define(['exports'], factory);
+    } else if (typeof exports !== 'undefined') {
+        factory(exports);
+    } else {
+        factory(root);
+    }
+}(this, function (exports) {
+
 var between = function (num, first, last) { return num >= first && num <= last; }
 function digit(code) { return between(code, 0x30,0x39); }
 function hexdigit(code) { return digit(code) || between(code, 0x41,0x46) || between(code, 0x61,0x66); }
@@ -679,8 +691,8 @@ UnicodeRangeToken.prototype.contains = function(code) {
 }
 
 
-// Make this usable from NodeJS
+// Exportation.
 // TODO: also export the various tokens objects?
-if (typeof(exports) != 'undefined') {
-    exports.tokenize = tokenize;
-}
+exports.tokenize = tokenize;
+
+}));


### PR DESCRIPTION
This pull request is mostly about adding line information to the tokenizer,
which in turn adds it to the parser.

It is opt-in, as in, it only appears with {loc:true} set in the options.
(I plan to use this in my CSS autocompletion project, https://github.com/espadrine/aulx)

I also added a commit to use UMD, in order to:
1. avoid leaking so many variables in the global object
2. support not only node and browser JS, but also AMD

The tests still pass fine.
