### PR TITLE
compatibility with version in Mozilla tree

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+(
+  (js-mode .
+     ((indent-tabs-mode . t)
+      (js-indent-level . 8)))
+  )

--- a/parse-css.js
+++ b/parse-css.js
@@ -1155,6 +1155,8 @@ function normalizeInput(input) {
 		return new TokenStream(tokenize(input));
 	if(input instanceof TokenStream)
 		return input;
+	if(typeof (input.next) == "function")
+		return new TokenStream(input);
 	if(input.length !== undefined)
 		return new TokenStream(input[Symbol.iterator]());
 	else throw SyntaxError(input);

--- a/parse-css.js
+++ b/parse-css.js
@@ -1165,10 +1165,7 @@ function parseARule(s) {
 	}
 	rule.startToken = startToken;
 	rule.endToken = s.token;
-	while(s.next() instanceof WhitespaceToken) s.consume();
-	if(s.next() instanceof EOFToken)
-		return rule;
-	throw SyntaxError();
+	return rule;
 }
 
 function parseADeclaration(s) {

--- a/parse-css.js
+++ b/parse-css.js
@@ -65,7 +65,10 @@ function stringFromCode(code) {
 	return String.fromCharCode(lead) + String.fromCharCode(trail);
 }
 
-function tokenize(str) {
+function tokenize(str, options) {
+	if (options === undefined) {
+		options = {loc: false};
+	}
 	str = preprocess(str);
 	var i = -1;
 	var tokens = [];
@@ -119,8 +122,6 @@ function tokenize(str) {
 		} else {
 			column -= 1;
 		}
-		locStart.line = line;
-		locStart.column = column;
 		return true;
 	};
 	var eof = function(codepoint) {
@@ -133,6 +134,8 @@ function tokenize(str) {
 	var consumeAToken = function() {
 		consumeComments();
 		consume();
+		locStart.line = line;
+		locStart.column = column;
 		if(whitespace(code)) {
 			while(whitespace(next())) consume();
 			return new WhitespaceToken;
@@ -539,7 +542,13 @@ function tokenize(str) {
 
 	var iterationCount = 0;
 	while(!eof(next())) {
-		tokens.push(consumeAToken());
+		var token = consumeAToken();
+		if (options.loc) {
+			token.loc = {};
+			token.loc.start = {line:locStart.line, column:locStart.column};
+			token.loc.end = {line:line, column:column};
+		}
+		tokens.push(token);
 		iterationCount++;
 		if(iterationCount > str.length*2) return "I'm infinite-looping!";
 	}

--- a/parse-css.js
+++ b/parse-css.js
@@ -42,7 +42,7 @@ function stringFromCode(code) {
 	return String.fromCharCode(lead) + String.fromCharCode(trail);
 }
 
-function tokenize(str, options) {
+function* tokenize(str, options) {
 	if (options === undefined) {
 		options = {loc: false,
 			   offsets: false,
@@ -50,7 +50,6 @@ function tokenize(str, options) {
 			   startOffset: 0};
 	}
 	var i = options.startOffset - 1;
-	var tokens = [];
 	var code;
 
 	// Line number information.
@@ -557,11 +556,10 @@ function tokenize(str, options) {
 		if (options.offsets) {
 			token.offset = {start: offsetStart, end: i};
 		}
-		tokens.push(token);
+		yield token;
 		iterationCount++;
 		if(iterationCount > str.length*2) return "I'm infinite-looping!";
 	}
-	return tokens;
 }
 
 function CSSParserToken() { throw "Abstract Base Class"; }
@@ -956,27 +954,39 @@ exports.CSSParserToken = CSSParserToken;
 exports.GroupingToken = GroupingToken;
 
 function TokenStream(tokens) {
-	// Assume that tokens is an array.
+	// Assume that tokens is a iterator.
 	this.tokens = tokens;
-	this.i = -1;
+	this.token = undefined;
+	this.stored = [];
 }
-TokenStream.prototype.tokenAt = function(i) {
-	if(i < this.tokens.length)
-		return this.tokens[i];
-	return new EOFToken();
-};
 TokenStream.prototype.consume = function(num) {
 	if(num === undefined) num = 1;
-	this.i += num;
-	this.token = this.tokenAt(this.i);
+	while (num-- > 0) {
+		if (this.stored.length > 0) {
+			this.token = this.stored.shift();
+		} else {
+			var n = this.tokens.next();
+			if (n.done) {
+				this.token = new EOFToken();
+				break;
+			}
+			this.token = n.value;
+		}
+	}
 	//console.log(this.i, this.token);
 	return true;
 };
 TokenStream.prototype.next = function() {
-	return this.tokenAt(this.i+1);
+	if (this.stored.length === 0) {
+		var n = this.tokens.next();
+		if (n.done)
+			return new EOFToken();
+		this.stored.push(n.value);
+	}
+	return this.stored[0];
 };
 TokenStream.prototype.reconsume = function() {
-	this.i--;
+	this.stored.unshift(this.token);
 };
 
 function parseerror(s, msg) {
@@ -1136,7 +1146,7 @@ function normalizeInput(input) {
 	if(input instanceof TokenStream)
 		return input;
 	if(input.length !== undefined)
-		return new TokenStream(input);
+		return new TokenStream(input[Symbol.iterator]());
 	else throw SyntaxError(input);
 }
 

--- a/parse-css.js
+++ b/parse-css.js
@@ -12,7 +12,7 @@
     }
 }(this, function (exports) {
 
-var between = function (num, first, last) { return num >= first && num <= last; }
+function between(num, first, last) { return num >= first && num <= last; }
 function digit(code) { return between(code, 0x30,0x39); }
 function hexdigit(code) { return digit(code) || between(code, 0x41,0x46) || between(code, 0x61,0x66); }
 function uppercaseletter(code) { return between(code, 0x41,0x5a); }
@@ -24,7 +24,6 @@ function namechar(code) { return namestartchar(code) || digit(code) || code == 0
 function nonprintable(code) { return between(code, 0,8) || code == 0xb || between(code, 0xe,0x1f) || code == 0x7f; }
 function newline(code) { return code == 0xa; }
 function whitespace(code) { return newline(code) || code == 9 || code == 0x20; }
-function badescape(code) { return newline(code) || isNaN(code); }
 function astral(code) { return code > 0xffff; }
 
 var maximumallowedcodepoint = 0x10ffff;
@@ -45,7 +44,7 @@ function preprocess(str) {
 			code = 0xa; i++;
 		}
 		if(code == 0xd || code == 0xc) code = 0xa;
-		if(code == 0x0) code = 0xfffd;
+		if(code === 0x0) code = 0xfffd;
 		if(between(code, 0xd800, 0xdbff) && between(str.charCodeAt(i+1), 0xdc00, 0xdfff)) {
 			// Decode a surrogate pair into an astral codepoint.
 			var lead = code - 0xd800;
@@ -93,7 +92,7 @@ function tokenize(str, options) {
 			return -1;
 		}
 		return str[i];
-	}
+	};
 	var next = function(num) {
 		if(num === undefined)
 			num = 1;
@@ -348,7 +347,7 @@ function tokenize(str, options) {
 				} else if(newline(next())) {
 					consume();
 				} else {
-					string += stringFromCode(consumeEscape())
+					string += stringFromCode(consumeEscape());
 				}
 			} else {
 				string += stringFromCode(code);
@@ -560,9 +559,9 @@ function tokenize(str, options) {
 function CSSParserToken() { throw "Abstract Base Class"; }
 CSSParserToken.prototype.toJSON = function() {
 	return {token: this.tokenType};
-}
-CSSParserToken.prototype.toString = function() { return this.tokenType; }
-CSSParserToken.prototype.toSource = function() { return ''+this; }
+};
+CSSParserToken.prototype.toString = function() { return this.tokenType; };
+CSSParserToken.prototype.toSource = function() { return ''+this; };
 
 function BadStringToken() { return this; }
 BadStringToken.prototype = Object.create(CSSParserToken.prototype);
@@ -575,18 +574,18 @@ BadURLToken.prototype.tokenType = "BADURL";
 function WhitespaceToken() { return this; }
 WhitespaceToken.prototype = Object.create(CSSParserToken.prototype);
 WhitespaceToken.prototype.tokenType = "WHITESPACE";
-WhitespaceToken.prototype.toString = function() { return "WS"; }
-WhitespaceToken.prototype.toSource = function() { return " "; }
+WhitespaceToken.prototype.toString = function() { return "WS"; };
+WhitespaceToken.prototype.toSource = function() { return " "; };
 
 function CDOToken() { return this; }
 CDOToken.prototype = Object.create(CSSParserToken.prototype);
 CDOToken.prototype.tokenType = "CDO";
-CDOToken.prototype.toSource = function() { return "<!--"; }
+CDOToken.prototype.toSource = function() { return "<!--"; };
 
 function CDCToken() { return this; }
 CDCToken.prototype = Object.create(CSSParserToken.prototype);
 CDCToken.prototype.tokenType = "CDC";
-CDCToken.prototype.toSource = function() { return "-->"; }
+CDCToken.prototype.toSource = function() { return "-->"; };
 
 function ColonToken() { return this; }
 ColonToken.prototype = Object.create(CSSParserToken.prototype);
@@ -654,7 +653,7 @@ ColumnToken.prototype.tokenType = "||";
 function EOFToken() { return this; }
 EOFToken.prototype = Object.create(CSSParserToken.prototype);
 EOFToken.prototype.tokenType = "EOF";
-EOFToken.prototype.toSource = function() { return ""; }
+EOFToken.prototype.toSource = function() { return ""; };
 
 function DelimToken(code) {
 	this.value = stringFromCode(code);
@@ -662,39 +661,39 @@ function DelimToken(code) {
 }
 DelimToken.prototype = Object.create(CSSParserToken.prototype);
 DelimToken.prototype.tokenType = "DELIM";
-DelimToken.prototype.toString = function() { return "DELIM("+this.value+")"; }
+DelimToken.prototype.toString = function() { return "DELIM("+this.value+")"; };
 DelimToken.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.value = this.value;
 	return json;
-}
+};
 DelimToken.prototype.toSource = function() {
 	if(this.value == "\\")
 		return "\\\n";
 	else
 		return this.value;
-}
+};
 
 function StringValuedToken() { throw "Abstract Base Class"; }
 StringValuedToken.prototype = Object.create(CSSParserToken.prototype);
 StringValuedToken.prototype.ASCIIMatch = function(str) {
 	return this.value.toLowerCase() == str.toLowerCase();
-}
+};
 StringValuedToken.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.value = this.value;
 	return json;
-}
+};
 
 function IdentToken(val) {
 	this.value = val;
 }
 IdentToken.prototype = Object.create(StringValuedToken.prototype);
 IdentToken.prototype.tokenType = "IDENT";
-IdentToken.prototype.toString = function() { return "IDENT("+this.value+")"; }
+IdentToken.prototype.toString = function() { return "IDENT("+this.value+")"; };
 IdentToken.prototype.toSource = function() {
 	return escapeIdent(this.value);
-}
+};
 
 function FunctionToken(val) {
 	this.value = val;
@@ -702,20 +701,20 @@ function FunctionToken(val) {
 }
 FunctionToken.prototype = Object.create(StringValuedToken.prototype);
 FunctionToken.prototype.tokenType = "FUNCTION";
-FunctionToken.prototype.toString = function() { return "FUNCTION("+this.value+")"; }
+FunctionToken.prototype.toString = function() { return "FUNCTION("+this.value+")"; };
 FunctionToken.prototype.toSource = function() {
 	return escapeIdent(this.value) + "(";
-}
+};
 
 function AtKeywordToken(val) {
 	this.value = val;
 }
 AtKeywordToken.prototype = Object.create(StringValuedToken.prototype);
 AtKeywordToken.prototype.tokenType = "AT-KEYWORD";
-AtKeywordToken.prototype.toString = function() { return "AT("+this.value+")"; }
+AtKeywordToken.prototype.toString = function() { return "AT("+this.value+")"; };
 AtKeywordToken.prototype.toSource = function() {
 	return "@" + escapeIdent(this.value);
-}
+};
 
 function HashToken(val) {
 	this.value = val;
@@ -723,20 +722,20 @@ function HashToken(val) {
 }
 HashToken.prototype = Object.create(StringValuedToken.prototype);
 HashToken.prototype.tokenType = "HASH";
-HashToken.prototype.toString = function() { return "HASH("+this.value+")"; }
+HashToken.prototype.toString = function() { return "HASH("+this.value+")"; };
 HashToken.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.value = this.value;
 	json.type = this.type;
 	return json;
-}
+};
 HashToken.prototype.toSource = function() {
 	if(this.type == "id") {
 		return "#" + escapeIdent(this.value);
 	} else {
 		return "#" + escapeHash(this.value);
 	}
-}
+};
 
 function StringToken(val) {
 	this.value = val;
@@ -745,17 +744,17 @@ StringToken.prototype = Object.create(StringValuedToken.prototype);
 StringToken.prototype.tokenType = "STRING";
 StringToken.prototype.toString = function() {
 	return '"' + escapeString(this.value) + '"';
-}
+};
 
 function URLToken(val) {
 	this.value = val;
 }
 URLToken.prototype = Object.create(StringValuedToken.prototype);
 URLToken.prototype.tokenType = "URL";
-URLToken.prototype.toString = function() { return "URL("+this.value+")"; }
+URLToken.prototype.toString = function() { return "URL("+this.value+")"; };
 URLToken.prototype.toSource = function() {
 	return 'url("' + escapeString(this.value) + '")';
-}
+};
 
 function NumberToken() {
 	this.value = null;
@@ -768,14 +767,14 @@ NumberToken.prototype.toString = function() {
 	if(this.type == "integer")
 		return "INT("+this.value+")";
 	return "NUMBER("+this.value+")";
-}
+};
 NumberToken.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.value = this.value;
 	json.type = this.type;
 	json.repr = this.repr;
 	return json;
-}
+};
 NumberToken.prototype.toSource = function() { return this.repr; };
 
 function PercentageToken() {
@@ -784,14 +783,14 @@ function PercentageToken() {
 }
 PercentageToken.prototype = Object.create(CSSParserToken.prototype);
 PercentageToken.prototype.tokenType = "PERCENTAGE";
-PercentageToken.prototype.toString = function() { return "PERCENTAGE("+this.value+")"; }
+PercentageToken.prototype.toString = function() { return "PERCENTAGE("+this.value+")"; };
 PercentageToken.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.value = this.value;
 	json.repr = this.repr;
 	return json;
-}
-PercentageToken.prototype.toSource = function() { return this.repr + "%"; }
+};
+PercentageToken.prototype.toSource = function() { return this.repr + "%"; };
 
 function DimensionToken() {
 	this.value = null;
@@ -801,7 +800,7 @@ function DimensionToken() {
 }
 DimensionToken.prototype = Object.create(CSSParserToken.prototype);
 DimensionToken.prototype.tokenType = "DIMENSION";
-DimensionToken.prototype.toString = function() { return "DIM("+this.value+","+this.unit+")"; }
+DimensionToken.prototype.toString = function() { return "DIM("+this.value+","+this.unit+")"; };
 DimensionToken.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.value = this.value;
@@ -809,7 +808,7 @@ DimensionToken.prototype.toJSON = function() {
 	json.repr = this.repr;
 	json.unit = this.unit;
 	return json;
-}
+};
 DimensionToken.prototype.toSource = function() {
 	var source = this.repr;
 	var unit = escapeIdent(this.unit);
@@ -819,7 +818,7 @@ DimensionToken.prototype.toSource = function() {
 		unit = "\\65 " + unit.slice(1, unit.length);
 	}
 	return source+unit;
-}
+};
 
 function escapeIdent(string) {
 	string = ''+string;
@@ -827,13 +826,13 @@ function escapeIdent(string) {
 	var firstcode = string.charCodeAt(0);
 	for(var i = 0; i < string.length; i++) {
 		var code = string.charCodeAt(i);
-		if(code == 0x0) {
+		if(code === 0x0) {
 			throw new InvalidCharacterError('Invalid character: the input contains U+0000.');
 		}
 
 		if(
 			between(code, 0x1, 0x1f) || code == 0x7f ||
-			(i == 0 && between(code, 0x30, 0x39)) ||
+			(i === 0 && between(code, 0x30, 0x39)) ||
 			(i == 1 && between(code, 0x30, 0x39) && firstcode == 0x2d)
 		) {
 			result += '\\' + code.toString(16) + ' ';
@@ -859,10 +858,9 @@ function escapeHash(string) {
 	// use escapeIdent() for that.
 	string = ''+string;
 	var result = '';
-	var firstcode = string.charCodeAt(0);
 	for(var i = 0; i < string.length; i++) {
 		var code = string.charCodeAt(i);
-		if(code == 0x0) {
+		if(code === 0x0) {
 			throw new InvalidCharacterError('Invalid character: the input contains U+0000.');
 		}
 
@@ -888,7 +886,7 @@ function escapeString(string) {
 	for(var i = 0; i < string.length; i++) {
 		var code = string.charCodeAt(i);
 
-		if(code == 0x0) {
+		if(code === 0x0) {
 			throw new InvalidCharacterError('Invalid character: the input contains U+0000.');
 		}
 
@@ -948,26 +946,26 @@ TokenStream.prototype.tokenAt = function(i) {
 	if(i < this.tokens.length)
 		return this.tokens[i];
 	return new EOFToken();
-}
+};
 TokenStream.prototype.consume = function(num) {
 	if(num === undefined) num = 1;
 	this.i += num;
 	this.token = this.tokenAt(this.i);
 	//console.log(this.i, this.token);
 	return true;
-}
+};
 TokenStream.prototype.next = function() {
 	return this.tokenAt(this.i+1);
-}
+};
 TokenStream.prototype.reconsume = function() {
 	this.i--;
-}
+};
 
 function parseerror(s, msg) {
 	console.log("Parse error at token " + s.i + ": " + s.token + ".\n" + msg);
 	return true;
 }
-function donothing(){ return true; };
+function donothing(){ return true; }
 
 function consumeAListOfRules(s, topLevel) {
 	var rules = [];
@@ -1145,10 +1143,11 @@ function parseARule(s) {
 	s = normalizeInput(s);
 	while(s.next() instanceof WhitespaceToken) s.consume();
 	if(s.next() instanceof EOFToken) throw SyntaxError();
+	var rule;
 	if(s.next() instanceof AtKeywordToken) {
-		var rule = consumeAnAtRule(s);
+		rule = consumeAnAtRule(s);
 	} else {
-		var rule = consumeAQualifiedRule(s);
+		rule = consumeAQualifiedRule(s);
 		if(!rule) throw SyntaxError();
 	}
 	while(s.next() instanceof WhitespaceToken) s.consume();
@@ -1163,7 +1162,7 @@ function parseADeclaration(s) {
 	if(!(s.next() instanceof IdentToken)) throw SyntaxError();
 	var decl = consumeADeclaration(s);
 	if(decl)
-		return decl
+		return decl;
 	else
 		throw SyntaxError();
 }
@@ -1191,7 +1190,7 @@ function parseAListOfComponentValues(s) {
 	while(true) {
 		var val = consumeAComponentValue(s);
 		if(val instanceof EOFToken)
-			return vals
+			return vals;
 		else
 			vals.push(val);
 	}
@@ -1221,10 +1220,10 @@ function parseACommaSeparatedListOfComponentValues(s) {
 function CSSParserRule() { throw "Abstract Base Class"; }
 CSSParserRule.prototype.toString = function(indent) {
 	return JSON.stringify(this,null,indent);
-}
+};
 CSSParserRule.prototype.toJSON = function() {
 	return {type:this.type, value:this.value};
-}
+};
 
 function Stylesheet() {
 	this.value = [];
@@ -1246,7 +1245,7 @@ AtRule.prototype.toJSON = function() {
 	json.name = this.name;
 	json.prelude = this.prelude;
 	return json;
-}
+};
 
 function QualifiedRule() {
 	this.prelude = [];
@@ -1259,7 +1258,7 @@ QualifiedRule.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.prelude = this.prelude;
 	return json;
-}
+};
 
 function Declaration(name) {
 	this.name = name;
@@ -1274,7 +1273,7 @@ Declaration.prototype.toJSON = function() {
 	json.name = this.name;
 	json.important = this.important;
 	return json;
-}
+};
 
 function SimpleBlock(type) {
 	this.name = type;
@@ -1287,7 +1286,7 @@ SimpleBlock.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.name = this.name;
 	return json;
-}
+};
 
 function Func(name) {
 	this.name = name;
@@ -1300,7 +1299,7 @@ Func.prototype.toJSON = function() {
 	var json = this.constructor.prototype.constructor.prototype.toJSON.call(this);
 	json.name = this.name;
 	return json;
-}
+};
 
 // Exportation.
 exports.CSSParserRule = CSSParserRule;

--- a/parse-css.js
+++ b/parse-css.js
@@ -1153,12 +1153,15 @@ function parseARule(s) {
 	while(s.next() instanceof WhitespaceToken) s.consume();
 	if(s.next() instanceof EOFToken) throw SyntaxError();
 	var rule;
-	if(s.next() instanceof AtKeywordToken) {
+	var startToken = s.next();
+	if(startToken instanceof AtKeywordToken) {
 		rule = consumeAnAtRule(s);
 	} else {
 		rule = consumeAQualifiedRule(s);
 		if(!rule) throw SyntaxError();
 	}
+	rule.startToken = startToken;
+	rule.endToken = s.token;
 	while(s.next() instanceof WhitespaceToken) s.consume();
 	if(s.next() instanceof EOFToken)
 		return rule;

--- a/parse-css.js
+++ b/parse-css.js
@@ -44,11 +44,21 @@ function stringFromCode(code) {
 
 function* tokenize(str, options) {
 	if (options === undefined) {
-		options = {loc: false,
-			   offsets: false,
-			   keepComments: false,
-			   startOffset: 0};
+		options = {};
 	}
+	if (options.loc === undefined) {
+		options.loc = false;
+	}
+	if (options.offsets === undefined) {
+		options.offsets = false;
+	}
+	if (options.keepComments === undefined) {
+		options.keepComments = false;
+	}
+	if (options.startOffset === undefined) {
+		options.startOffset = 0;
+	}
+
 	var i = options.startOffset - 1;
 	var code;
 

--- a/parse-css.js
+++ b/parse-css.js
@@ -976,6 +976,9 @@ TokenStream.prototype.consume = function(num) {
 			this.token = this.stored.shift();
 		} else {
 			var n = this.tokens.next();
+			while (!n.done && n.value instanceof CommentToken) {
+				n = this.tokens.next();
+			}
 			if (n.done) {
 				this.token = new EOFToken();
 				break;
@@ -989,6 +992,9 @@ TokenStream.prototype.consume = function(num) {
 TokenStream.prototype.next = function() {
 	if (this.stored.length === 0) {
 		var n = this.tokens.next();
+		while (!n.done && n.value instanceof CommentToken) {
+			n = this.tokens.next();
+		}
 		if (n.done)
 			return new EOFToken();
 		this.stored.push(n.value);

--- a/parse-css.js
+++ b/parse-css.js
@@ -1013,9 +1013,6 @@ function consumeAnAtRule(s) {
 		} else if(s.token instanceof OpenCurlyToken) {
 			rule.value = consumeASimpleBlock(s);
 			return rule;
-		} else if(s.token instanceof SimpleBlock && s.token.name == "{") {
-			rule.value = s.token;
-			return rule;
 		} else {
 			s.reconsume();
 			rule.prelude.push(consumeAComponentValue(s));
@@ -1031,9 +1028,6 @@ function consumeAQualifiedRule(s) {
 			return;
 		} else if(s.token instanceof OpenCurlyToken) {
 			rule.value = consumeASimpleBlock(s);
-			return rule;
-		} else if(s.token instanceof SimpleBlock && s.token.name == "{") {
-			rule.value = s.token;
 			return rule;
 		} else {
 			s.reconsume();

--- a/parse-css.js
+++ b/parse-css.js
@@ -44,9 +44,12 @@ function stringFromCode(code) {
 
 function tokenize(str, options) {
 	if (options === undefined) {
-		options = {loc: false, offsets: false, keepComments: false};
+		options = {loc: false,
+			   offsets: false,
+			   keepComments: false,
+			   startOffset: 0};
 	}
-	var i = -1;
+	var i = options.startOffset - 1;
 	var tokens = [];
 	var code;
 

--- a/parse-css.js
+++ b/parse-css.js
@@ -44,7 +44,7 @@ function stringFromCode(code) {
 
 function tokenize(str, options) {
 	if (options === undefined) {
-		options = {loc: false, keepComments: false};
+		options = {loc: false, offsets: false, keepComments: false};
 	}
 	var i = -1;
 	var tokens = [];
@@ -61,6 +61,7 @@ function tokenize(str, options) {
 		column = 0;
 	};
 	var locStart = {line:line, column:column};
+	var offsetStart = i;
 
 	var codepoint = function(i) {
 		if(i >= str.length) {
@@ -135,6 +136,7 @@ function tokenize(str, options) {
 		}
 		locStart.line = line;
 		locStart.column = column;
+		offsetStart = i;
 		if(whitespace(code)) {
 			while(whitespace(next())) consume();
 			return new WhitespaceToken;
@@ -548,6 +550,9 @@ function tokenize(str, options) {
 			token.loc = {};
 			token.loc.start = {line:locStart.line, column:locStart.column};
 			token.loc.end = {line:line, column:column};
+		}
+		if (options.offsets) {
+			token.offset = {start: offsetStart, end: i};
 		}
 		tokens.push(token);
 		iterationCount++;

--- a/parse-css.js
+++ b/parse-css.js
@@ -1107,6 +1107,7 @@ function consumeAComponentValue(s) {
 function consumeASimpleBlock(s) {
 	var mirror = s.token.mirror;
 	var block = new SimpleBlock(s.token.value);
+	block.startToken = s.token;
 	while(s.consume()) {
 		if(s.token instanceof EOFToken || (s.token instanceof GroupingToken && s.token.value == mirror))
 			return block;

--- a/parse-css.js
+++ b/parse-css.js
@@ -1045,7 +1045,7 @@ function consumeAListOfDeclarations(s) {
 			if(decl = consumeADeclaration(new TokenStream(temp))) decls.push(decl);
 		} else {
 			parseerror(s);
-			reconsume();
+			s.reconsume();
 			while(!(s.next() instanceof SemicolonToken || s.next() instanceof EOFToken))
 				consumeAComponentValue(s);
 		}

--- a/parse-css.js
+++ b/parse-css.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function (root, factory) {
     // Universal Module Definition (UMD) to support AMD, CommonJS/Node.js,
     // Rhino, and plain browser loading.

--- a/test.html
+++ b/test.html
@@ -117,18 +117,20 @@ var TESTS = [
 ];
 
 var total = TESTS.length, failures = 0,
-		i, test, tokens, sheet, dump, expected_dump;
+		i, test, sheet, dump, expected_dump;
 
 for (i = 0; i < total; i++) {
 		test = TESTS[i];
-		tokens = tokenize(test.css);
-		sheet = parseAStylesheet(tokens);
+		console.log(' CSS = ' + test.css);
+		sheet = parseAStylesheet(test.css);
+		console.log( ' sheet = ' + sheet);
 		dump = sheet.toString('  ');
+		console.log(' dump = ' + dump);
 		expected_dump = JSON.stringify(test.expected, null, '  ');
 		if (dump == expected_dump) {
 				log('Test '+i+' of '+total+': PASS');
 		} else {
-				log('Test '+i+' of '+total+': FAIL\nCSS: '+test.css+'\nTokens: '+tokens.join(' '));
+				log('Test '+i+' of '+total+': FAIL\nCSS: '+test.css);
 				log(diffString(expected_dump, dump));
 				failures++;
 		}


### PR DESCRIPTION
Firefox imported an earlier version of this parser.  These patches fix a couple of issues I noticed while trying to import the newer parser.

First, the Firefox CSS parser computes columns using characters, not code points.

Second, the use of this in the devtools required locations on the tokens.  This adds the location logic back to the parser.  I did it via an options object as that is how it worked before; but if you'd rather it be done differently (or unconditionally), just let me know.