### PR TITLE
point to correct file

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git://github.com/tabatkins/parse-css.git"
   },
-  "main": "index",
+  "main": "parse-css.js",
   "homepage": "https://github.com/tabatkins/parse-css",
   "contributors": [
     {


### PR DESCRIPTION
Right now if you do `npm install parse-css` then `require('parse-css')` you get an error `Error: Cannot find module 'parse-css'` since the package.json points to the wrong place