### PR TITLE
Update parse-css.js

### DIFF
--- a/parse-css.js
+++ b/parse-css.js
@@ -1030,7 +1030,7 @@ function consumeAListOfDeclarations(s) {
 			if(decl = consumeADeclaration(new TokenStream(temp))) decls.push(decl);
 		} else {
 			parseerror(s);
-			reconsume();
+			s.reconsume();
 			while(!(s.next() instanceof SemicolonToken || s.next() instanceof EOFToken))
 				consumeAComponentValue(s);
 		}


### PR DESCRIPTION
I think this is a small typo as the reconsume method isn't a free function at this scope.