### PR TITLE
Fix calculation of Unicode surrogate pairs

### DIFF
--- a/parse-css.js
+++ b/parse-css.js
@@ -47,7 +47,7 @@ function preprocess(str) {
 			// Decode a surrogate pair into an astral codepoint.
 			var lead = code - 0xd800;
 			var trail = str.charCodeAt(i+1) - 0xdc00;
-			code = Math.pow(2, 20) + lead * Math.pow(2, 10) + trail;
+			code = Math.pow(2, 16) + lead * Math.pow(2, 10) + trail;
 			i++;
 		}
 		codepoints.push(code);
@@ -58,7 +58,7 @@ function preprocess(str) {
 function stringFromCode(code) {
 	if(code <= 0xffff) return String.fromCharCode(code);
 	// Otherwise, encode astral char as surrogate pair.
-	code -= Math.pow(2, 20);
+	code -= Math.pow(2, 16);
 	var lead = Math.floor(code/Math.pow(2, 10)) + 0xd800;
 	var trail = code % Math.pow(2, 10) + 0xdc00;
 	return String.fromCharCode(lead) + String.fromCharCode(trail);


### PR DESCRIPTION
See section 3.7 of Unicode 3.0 (later versions are not as clear regarding how to do the surrogate pairs calculation): https://www.unicode.org/versions/Unicode3.0.0/ch03.pdf
N = (H - D800_16) * 400_16 + (L - DC00_16) + 10000_16.
10000_16 is 2^16, not 2^20.