### PR TITLE
Use spec-consistent property names

### DIFF
--- a/parse-css.js
+++ b/parse-css.js
@@ -529,7 +529,6 @@ class BadURLToken extends CSSParserToken {
   }
   toSource() { return "url(BAD URL)"}
 }
-BadURLToken.prototype.tokenType = "BADURL";
 
 class WhitespaceToken extends CSSParserToken {
   constructor() {

--- a/parse-css.js
+++ b/parse-css.js
@@ -156,8 +156,8 @@ function tokenize(str) {
     else if(code == 0x22) return consumeAStringToken();
     else if(code == 0x23) {
       if(namechar(next()) || areAValidEscape(next(1), next(2))) {
-        const isIdent = wouldStartAnIdentifier(next(1), next(2), next(3));
-        return new HashToken(consumeAName(), isIdent);
+        const type = wouldStartAnIdentifier(next(1), next(2), next(3)) ? 'id' : 'unrestricted';
+        return new HashToken(consumeAName(), type);
       } else {
         return new DelimToken(code);
       }
@@ -255,15 +255,15 @@ function tokenize(str) {
   };
 
   var consumeANumericToken = function() {
-    var {value, isInteger, sign} = consumeANumber();
+    var {value, type, sign} = consumeANumber();
     if(wouldStartAnIdentifier(next(1), next(2), next(3))) {
       const unit = consumeAName();
-      return new DimensionToken(value, isInteger, unit, sign);
+      return new DimensionToken(value, type, unit, sign);
     } else if(next() == 0x25) {
       consume();
       return new PercentageToken(value, sign);
     } else {
-      return new NumberToken(value, isInteger, sign);
+      return new NumberToken(value, type, sign);
     }
   };
 
@@ -428,7 +428,7 @@ function tokenize(str) {
   };
 
   var consumeANumber = function() {
-    let isInteger = true;
+    let type = 'integer';
     let sign;
     let numberPart = "";
     let exponentPart = "";
@@ -448,7 +448,7 @@ function tokenize(str) {
         consume();
         numberPart += String.fromCodePoint(code);
       }
-      isInteger = false;
+      type = 'number';
     }
     var c1 = next(1), c2 = next(2), c3 = next(3);
     const eDigit = (c1 == 0x45 || c1 == 0x65) && digit(c2);
@@ -463,7 +463,7 @@ function tokenize(str) {
         consume();
         exponentPart += String.fromCodePoint(code);
       }
-      isInteger = false;
+      type = 'number';
     }
 
     // parse with native engine to prevent a precision issue
@@ -472,7 +472,7 @@ function tokenize(str) {
     // let value = +numberPart;
     // if(exponentPart) value = value * Math.pow(10, +exponentPart);
 
-    return {value, isInteger, sign};
+    return {value, type, sign};
   };
 
   var consumeTheRemnantsOfABadURL = function() {
@@ -504,12 +504,12 @@ function tokenize(str) {
 }
 
 class CSSParserToken {
-  constructor(type) {
-    this.type = type;
+  constructor(TYPE) {
+    this.TYPE = TYPE;
   }
 
-  toJSON() { return {type:this.type}; }
-  toString() { return this.type; }
+  toJSON() { return {TYPE:this.TYPE}; }
+  toString() { return this.TYPE; }
   toSource() { throw new Error("Not implemented."); }
 }
 //toJSON()
@@ -639,7 +639,7 @@ class DelimToken extends CSSParserToken {
     this.value = val;
   }
   toString() { return `DELIM(${this.value})`; }
-  toJSON() { return {type:this.type, value:this.value}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value}; }
   toSource() {
     if(this.value == "\\") return "\\\n";
     return this.value;
@@ -652,7 +652,7 @@ class IdentToken extends CSSParserToken {
     this.value = val;
   }
   toString() { return `IDENT(${this.value})`; }
-  toJSON() { return {type:this.type, value:this.value}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value}; }
   toSource() { return escapeIdent(this.value); }
 }
 
@@ -663,7 +663,7 @@ class FunctionToken extends CSSParserToken {
     this.mirror = CloseParenToken;
   }
   toString() { return `FUNCTION(${this.value})`; }
-  toJSON() { return {type:this.type, value:this.value}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value}; }
   toSource() { return escapeIdent(this.value) + "("; }
 }
 
@@ -673,20 +673,20 @@ class AtKeywordToken extends CSSParserToken {
     this.value = val;
   }
   toString() { return `AT(${this.value})`; }
-  toJSON() { return {type:this.type, value:this.value }; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value }; }
   toSource() { return "@" + escapeIdent(this.value); }
 }
 
 class HashToken extends CSSParserToken {
-  constructor(val, isIdent) {
+  constructor(val, type) {
     super("HASH");
     this.value = val;
-    this.isIdent = isIdent;
+    this.type = type;
   }
   toString() { return `HASH(${this.value})`; }
-  toJSON() { return {type:this.type, value:this.value, isIdent:this.isIdent}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value, type:this.type}; }
   toSource() {
-    if(this.isIdent) {
+    if(this.type === 'id') {
       return "#" + escapeIdent(this.value);
     }
     return "#" + escapeHash(this.value);
@@ -699,7 +699,7 @@ class StringToken extends CSSParserToken {
     this.value = val;
   }
   toString() { return `STRING(${this.value})`; }
-  toJSON() { return {type:this.type, value:this.value}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value}; }
   toSource() { return `"${escapeString(this.value)}"`; }
 }
 
@@ -709,23 +709,23 @@ class URLToken extends CSSParserToken {
     this.value = val;
   }
   toString() { return `URL(${this.value})`; }
-  toJSON() { return {type:this.type, value:this.value}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value}; }
   toSource() { return `url("${escapeString(this.value)}")`; }
 }
 
 class NumberToken extends CSSParserToken {
-  constructor(val, isInteger, sign=undefined) {
+  constructor(val, type, sign=undefined) {
     super("NUMBER");
     this.value = val;
-    this.isInteger = isInteger;
+    this.type = type;
     this.sign = sign;
   }
   toString() {
-    const name = this.isInteger ? "INT" : "NUMBER";
+    const name = this.type === 'integer' ? "INT" : "NUMBER";
     const sign = this.sign == "+" ? "+" : "";
     return `${name}(${sign}${this.value})`;
   }
-  toJSON() { return {type:this.type, value:this.value, isInteger:this.isInteger, sign:this.sign}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value, type:this.type, sign:this.sign}; }
   toSource() { return formatNumber(this.value, this.sign); }
 }
 
@@ -739,15 +739,15 @@ class PercentageToken extends CSSParserToken {
     const sign = this.sign == "+" ? "+" : "";
     return `PERCENTAGE(${sign}${this.value})`;
   }
-  toJSON() { return {type:this.type, value:this.value, sign:this.sign}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value, sign:this.sign}; }
   toSource() { return `${formatNumber(this.value, this.sign)}%`; }
 }
 
 class DimensionToken extends CSSParserToken {
-  constructor(val, isInteger, unit, sign=undefined) {
+  constructor(val, type, unit, sign=undefined) {
     super("DIMENSION");
     this.value = val;
-    this.isInteger = isInteger;
+    this.type = type;
     this.unit = unit;
     this.sign = sign;
   }
@@ -755,7 +755,7 @@ class DimensionToken extends CSSParserToken {
     const sign = this.sign == "+" ? "+" : "";
     return `DIM(${sign}${this.value}, ${this.unit})`;
   }
-  toJSON() { return {type:this.type, value:this.value, isInteger:this.isInteger, unit:this.unit, sign:this.sign}; }
+  toJSON() { return {TYPE:this.TYPE, value:this.value, type:this.type, unit:this.unit, sign:this.sign}; }
   toSource() {
     let unit = escapeIdent(this.unit);
     if(unit[0].toLowerCase() == "e" && (unit[1] == "-" || digit(unit[1].charCodeAt(0)))) {
@@ -1142,24 +1142,24 @@ function isValidInContext(construct, context) {
   // Trivial validator, without any special CSS knowledge.
 
   // All at-rules are valid, who cares.
-  if(construct.type == "AT-RULE") return true;
+  if(construct.TYPE == "AT-RULE") return true;
 
   // Exclude qualified rules that ended up with a semicolon
   // in their prelude.
   // (Can only happen at the top level of a stylesheet.)
-  if(construct.type == "QUALIFIED-RULE") {
+  if(construct.TYPE == "QUALIFIED-RULE") {
     for(const val of construct.prelude) {
-      if(val.type == "SEMICOLON") return false;
+      if(val.TYPE == "SEMICOLON") return false;
     }
     return true;
   }
 
   // Exclude properties that ended up with a {}-block
   // in their value, unless they're custom.
-  if(construct.type == "DECLARATION") {
+  if(construct.TYPE == "DECLARATION") {
     if(construct.name.slice(0, 2) == "--") return true;
     for(const val of construct.value) {
-      if(val.type == "BLOCK" && val.name == "{") return false;
+      if(val.TYPE == "BLOCK" && val.name == "{") return false;
     }
     return true;
   }
@@ -1248,7 +1248,7 @@ function parseACommaSeparatedListOfComponentValues(s) {
 
 
 class CSSParserRule {
-  constructor(type) { this.type = type; }
+  constructor(TYPE) { this.TYPE = TYPE; }
   toString(indent) {
     return JSON.stringify(this,null,indent);
   }
@@ -1262,7 +1262,7 @@ class Stylesheet extends CSSParserRule {
   }
   toJSON() {
     return {
-      type: this.type,
+      TYPE: this.TYPE,
       rules: this.rules,
     }
   }
@@ -1282,7 +1282,7 @@ class AtRule extends CSSParserRule {
   }
   toJSON() {
     return {
-      type: this.type,
+      TYPE: this.TYPE,
       name: this.name,
       prelude: this.prelude,
       declarations: this.declarations,
@@ -1318,7 +1318,7 @@ class QualifiedRule extends CSSParserRule {
   }
   toJSON() {
     return {
-      type: this.type,
+      TYPE: this.TYPE,
       prelude: this.prelude,
       declarations: this.declarations,
       rules: this.rules,
@@ -1349,7 +1349,7 @@ class Declaration extends CSSParserRule {
   }
   toJSON() {
     return {
-      type: this.type,
+      TYPE: this.TYPE,
       name: this.name,
       value: this.value,
       important: this.important,
@@ -1367,15 +1367,15 @@ class Declaration extends CSSParserRule {
 }
 
 class SimpleBlock extends CSSParserRule {
-  constructor(type) {
+  constructor(TYPE) {
     super("BLOCK");
-    this.name = type;
+    this.name = TYPE;
     this.value = [];
     return this;
   }
   toJSON() {
     return {
-      type: this.type,
+      TYPE: this.TYPE,
       name: this.name,
       value: this.value,
     }
@@ -1395,7 +1395,7 @@ class Func extends CSSParserRule {
   }
   toJSON() {
     return {
-      type: this.type,
+      TYPE: this.TYPE,
       name: this.name,
       value: this.value,
     }

--- a/tests.js
+++ b/tests.js
@@ -26,14 +26,14 @@ var TESTS = [
     parser: "",
     css: `\u{20000},\u{0},\uD800,\uDFFF`,
     expected: [
-      {type: "IDENT", value: "\u{20000}"},
-      {type: "COMMA"},
-      {type: "IDENT", value: "\uFFFD"},
-      {type: "COMMA"},
-      {type: "IDENT", value: "\uFFFD"},
-      {type: "COMMA"},
-      {type: "IDENT", value: "\uFFFD"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "\u{20000}"},
+      {TYPE: "COMMA"},
+      {TYPE: "IDENT", value: "\uFFFD"},
+      {TYPE: "COMMA"},
+      {TYPE: "IDENT", value: "\uFFFD"},
+      {TYPE: "COMMA"},
+      {TYPE: "IDENT", value: "\uFFFD"},
+      {TYPE: "EOF"},
     ]
   },
 
@@ -43,1013 +43,1013 @@ var TESTS = [
   {
     parser: "",
     css: "(",
-    expected: [{type: "OPEN-PAREN"}, {type: "EOF"}],
+    expected: [{TYPE: "OPEN-PAREN"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ")",
-    expected: [{type: "CLOSE-PAREN"}, {type: "EOF"}],
+    expected: [{TYPE: "CLOSE-PAREN"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "[",
-    expected: [{type: "OPEN-SQUARE"}, {type: "EOF"}],
+    expected: [{TYPE: "OPEN-SQUARE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "]",
-    expected: [{type: "CLOSE-SQUARE"}, {type: "EOF"}],
+    expected: [{TYPE: "CLOSE-SQUARE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ",",
-    expected: [{type: "COMMA"}, {type: "EOF"}],
+    expected: [{TYPE: "COMMA"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ":",
-    expected: [{type: "COLON"}, {type: "EOF"}],
+    expected: [{TYPE: "COLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ";",
-    expected: [{type: "SEMICOLON"}, {type: "EOF"}],
+    expected: [{TYPE: "SEMICOLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ")[",
-    expected: [{type: "CLOSE-PAREN"}, {type: "OPEN-SQUARE"}, {type: "EOF"}],
+    expected: [{TYPE: "CLOSE-PAREN"}, {TYPE: "OPEN-SQUARE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "[)",
-    expected: [{type: "OPEN-SQUARE"}, {type: "CLOSE-PAREN"}, {type: "EOF"}],
+    expected: [{TYPE: "OPEN-SQUARE"}, {TYPE: "CLOSE-PAREN"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "{}",
-    expected: [{type: "OPEN-CURLY"}, {type: "CLOSE-CURLY"}, {type: "EOF"}],
+    expected: [{TYPE: "OPEN-CURLY"}, {TYPE: "CLOSE-CURLY"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ",,",
-    expected: [{type: "COMMA"}, {type: "COMMA"}, {type: "EOF"}],
+    expected: [{TYPE: "COMMA"}, {TYPE: "COMMA"}, {TYPE: "EOF"}],
   },
 
   // -- MultipleCharacterTokens
   {
     parser: "",
     css: "~=",
-    expected: [{type: "DELIM", value: '~'}, {type: "DELIM", value: '='}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '~'}, {TYPE: "DELIM", value: '='}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "|=",
-    expected: [{type: "DELIM", value: '|'}, {type: "DELIM", value: '='}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '|'}, {TYPE: "DELIM", value: '='}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "^=",
-    expected: [{type: "DELIM", value: '^'}, {type: "DELIM", value: '='}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '^'}, {TYPE: "DELIM", value: '='}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "$=",
-    expected: [{type: "DELIM", value: '$'}, {type: "DELIM", value: '='}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '$'}, {TYPE: "DELIM", value: '='}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "*=",
-    expected: [{type: "DELIM", value: '*'}, {type: "DELIM", value: '='}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '*'}, {TYPE: "DELIM", value: '='}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "||",
-    expected: [{type: "DELIM", value: '|'}, {type: "DELIM", value: '|'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '|'}, {TYPE: "DELIM", value: '|'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "|||",
-    expected: [{type: "DELIM", value: '|'}, {type: "DELIM", value: '|'}, {type: "DELIM", value: '|'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '|'}, {TYPE: "DELIM", value: '|'}, {TYPE: "DELIM", value: '|'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "<!--",
-    expected: [{type: "CDO"}, {type: "EOF"}],
+    expected: [{TYPE: "CDO"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "<!---",
-    expected: [{type: "CDO"}, {type: "DELIM", value: '-'}, {type: "EOF"}],
+    expected: [{TYPE: "CDO"}, {TYPE: "DELIM", value: '-'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-->",
-    expected: [{type: "CDC"}, {type: "EOF"}],
+    expected: [{TYPE: "CDC"}, {TYPE: "EOF"}],
   },
 
   // -- DelimiterToken
   {
     parser: "",
     css: "^",
-    expected: [{type: "DELIM", value: '^'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '^'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "*",
-    expected: [{type: "DELIM", value: '*'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '*'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "%",
-    expected: [{type: "DELIM", value: '%'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '%'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "~",
-    expected: [{type: "DELIM", value: '~'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '~'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "&",
-    expected: [{type: "DELIM", value: '&'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '&'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "|",
-    expected: [{type: "DELIM", value: '|'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '|'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\x7f",
-    expected: [{type: "DELIM", value: '\x7f'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '\x7f'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\x01",
-    expected: [{type: "DELIM", value: '\x01'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '\x01'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "~-",
-    expected: [{type: "DELIM", value: '~'}, {type: "DELIM", value: '-'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '~'}, {TYPE: "DELIM", value: '-'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "^|",
-    expected: [{type: "DELIM", value: '^'}, {type: "DELIM", value: '|'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '^'}, {TYPE: "DELIM", value: '|'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "$~",
-    expected: [{type: "DELIM", value: '$'}, {type: "DELIM", value: '~'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '$'}, {TYPE: "DELIM", value: '~'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "*^",
-    expected: [{type: "DELIM", value: '*'}, {type: "DELIM", value: '^'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '*'}, {TYPE: "DELIM", value: '^'}, {TYPE: "EOF"}],
   },
 
   // -- WhitespaceTokens
   {
     parser: "",
     css: "   ",
-    expected: [{type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\n\rS",
-    expected: [{type: "WHITESPACE"}, {type: "IDENT", value: "S"}, {type: "EOF"}],
+    expected: [{TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "S"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "   *",
-    expected: [{type: "WHITESPACE"}, {type: "DELIM", value: '*'}, {type: "EOF"}],
+    expected: [{TYPE: "WHITESPACE"}, {TYPE: "DELIM", value: '*'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\r\n\f\t2",
-    expected: [{type: "WHITESPACE"}, {type: "NUMBER", value: 2, isInteger: true}, {type: "EOF"}],
+    expected: [{TYPE: "WHITESPACE"}, {TYPE: "NUMBER", value: 2, type: "integer"}, {TYPE: "EOF"}],
   },
 
   // -- Escapes
   {
     parser: "",
     css: "hel\\6Co",
-    expected: [{type: "IDENT", value: "hello"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "hello"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\26 B",
-    expected: [{type: "IDENT", value: "&B"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "&B"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'hel\\6c o'",
-    expected: [{type: "STRING", value: "hello"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "hello"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'spac\\65\r\ns'",
-    expected: [{type: "STRING", value: "spaces"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "spaces"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "spac\\65\r\ns",
-    expected: [{type: "IDENT", value: "spaces"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "spaces"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "spac\\65\n\rs",
-    expected: [{type: "IDENT", value: "space"}, {type: "WHITESPACE"}, {type: "IDENT", value: "s"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "space"}, {TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "s"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "sp\\61\tc\\65\fs",
-    expected: [{type: "IDENT", value: "spaces"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "spaces"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "hel\\6c  o",
-    expected: [{type: "IDENT", value: "hell"}, {type: "WHITESPACE"}, {type: "IDENT", value: "o"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "hell"}, {TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "o"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "test\\\n",
-    expected: [{type: "IDENT", value: "test"}, {type: "DELIM", value: '\\'}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "test"}, {TYPE: "DELIM", value: '\\'}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "test\\D799",
-    expected: [{type: "IDENT", value: "test\uD799"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "test\uD799"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\E000",
-    expected: [{type: "IDENT", value: "\uE000"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\uE000"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "te\\s\\t",
-    expected: [{type: "IDENT", value: "test"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "test"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "spaces\\ in\\\tident",
-    expected: [{type: "IDENT", value: "spaces in\tident"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "spaces in\tident"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\.\\,\\:\\!",
-    expected: [{type: "IDENT", value: ".,:!"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: ".,:!"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\\r",
-    expected: [{type: "DELIM", value: '\\'}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '\\'}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\\f",
-    expected: [{type: "DELIM", value: '\\'}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '\\'}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\\r\n",
-    expected: [{type: "DELIM", value: '\\'}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '\\'}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "null\\\0",
-    expected: [{type: "IDENT", value: "null\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "null\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "null\\\0\0",
-    expected: [{type: "IDENT", value: "null\uFFFD\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "null\uFFFD\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "null\\0",
-    expected: [{type: "IDENT", value: "null\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "null\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "null\\0",
-    expected: [{type: "IDENT", value: "null\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "null\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "null\\0000",
-    expected: [{type: "IDENT", value: "null\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "null\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "large\\110000",
-    expected: [{type: "IDENT", value: "large\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "large\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "large\\23456a",
-    expected: [{type: "IDENT", value: "large\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "large\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "surrogate\\D800",
-    expected: [{type: "IDENT", value: "surrogate\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "surrogate\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "surrogate\\0DABC",
-    expected: [{type: "IDENT", value: "surrogate\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "surrogate\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\00DFFFsurrogate",
-    expected: [{type: "IDENT", value: "\uFFFDsurrogate"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\uFFFDsurrogate"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\10fFfF",
-    expected: [{type: "IDENT", value: "\u{10ffff}"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\u{10ffff}"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\10fFfF0",
-    expected: [{type: "IDENT", value: "\u{10ffff}0"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\u{10ffff}0"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\\10000000",
-    expected: [{type: "IDENT", value: "\u{100000}00"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\u{100000}00"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "eof\\",
-    expected: [{type: "IDENT", value: "eof\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "eof\uFFFD"}, {TYPE: "EOF"}],
   },
 
   // -- IdentToken
   {
     parser: "",
     css: "simple-ident",
-    expected: [{type: "IDENT", value: "simple-ident"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "simple-ident"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "testing123",
-    expected: [{type: "IDENT", value: "testing123"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "testing123"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "hello!",
-    expected: [{type: "IDENT", value: "hello"}, {type: "DELIM", value: '!'}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "hello"}, {TYPE: "DELIM", value: '!'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "world\x05",
-    expected: [{type: "IDENT", value: "world"}, {type: "DELIM", value: '\x05'}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "world"}, {TYPE: "DELIM", value: '\x05'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "_under score",
-    expected: [{type: "IDENT", value: "_under"}, {type: "WHITESPACE"}, {type: "IDENT", value: "score"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "_under"}, {TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "score"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-_underscore",
-    expected: [{type: "IDENT", value: "-_underscore"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "-_underscore"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-text",
-    expected: [{type: "IDENT", value: "-text"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "-text"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-\\6d",
-    expected: [{type: "IDENT", value: "-m"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "-m"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "--abc",
-    expected: [{type: "IDENT", value: "--abc"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "--abc"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "--",
-    expected: [{type: "IDENT", value: "--"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "--"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "--11",
-    expected: [{type: "IDENT", value: "--11"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "--11"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "---",
-    expected: [{type: "IDENT", value: "---"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "---"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\u2003",  // em-space
-    expected: [{type: "DELIM", value: "\u2003"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: "\u2003"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\u{A0}",  // non-breaking space
-    expected: [{type: "DELIM", value: "\u{A0}"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: "\u{A0}"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\u1234",
-    expected: [{type: "IDENT", value: "\u1234"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\u1234"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\u{12345}",
-    expected: [{type: "IDENT", value: "\u{12345}"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\u{12345}"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\0",
-    expected: [{type: "IDENT", value: "\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "ab\0c",
-    expected: [{type: "IDENT", value: "ab\uFFFDc"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "ab\uFFFDc"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "ab\0c",
-    expected: [{type: "IDENT", value: "ab\uFFFDc"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "ab\uFFFDc"}, {TYPE: "EOF"}],
   },
 
   // -- FunctionToken
   {
     parser: "",
     css: "scale(2)",
-    expected: [{type: "FUNCTION", value: "scale"}, {type: "NUMBER", value: 2, isInteger: true}, {type: "CLOSE-PAREN"}, {type: "EOF"}],
+    expected: [{TYPE: "FUNCTION", value: "scale"}, {TYPE: "NUMBER", value: 2, type: "integer"}, {TYPE: "CLOSE-PAREN"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "foo-bar\\ baz(",
-    expected: [{type: "FUNCTION", value: "foo-bar baz"}, {type: "EOF"}],
+    expected: [{TYPE: "FUNCTION", value: "foo-bar baz"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "fun\\(ction(",
-    expected: [{type: "FUNCTION", value: "fun(ction"}, {type: "EOF"}],
+    expected: [{TYPE: "FUNCTION", value: "fun(ction"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-foo(",
-    expected: [{type: "FUNCTION", value: "-foo"}, {type: "EOF"}],
+    expected: [{TYPE: "FUNCTION", value: "-foo"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "url(\"foo.gif\"",
-    expected: [{type: "FUNCTION", value: "url"}, {type: "STRING", value: "foo.gif"}, {type: "EOF"}],
+    expected: [{TYPE: "FUNCTION", value: "url"}, {TYPE: "STRING", value: "foo.gif"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "foo(  \'bar.gif\'",
-    expected: [{type: "FUNCTION", value: "foo"}, {type: "WHITESPACE"}, {type: "STRING", value: "bar.gif"}, {type: "EOF"}],
+    expected: [{TYPE: "FUNCTION", value: "foo"}, {TYPE: "WHITESPACE"}, {TYPE: "STRING", value: "bar.gif"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "url(  \'bar.gif\'",
-    expected: [{type: "FUNCTION", value: "url"}, {type: "WHITESPACE"}, {type: "STRING", value: "bar.gif"}, {type: "EOF"}],
+    expected: [{TYPE: "FUNCTION", value: "url"}, {TYPE: "WHITESPACE"}, {TYPE: "STRING", value: "bar.gif"}, {TYPE: "EOF"}],
   },
 
   // -- AtKeywordToken
   {
     parser: "",
     css: "@at-keyword",
-    expected: [{type: "AT-KEYWORD", value: "at-keyword"}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "at-keyword"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@testing123",
-    expected: [{type: "AT-KEYWORD", value: "testing123"}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "testing123"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@hello!",
-    expected: [{type: "AT-KEYWORD", value: "hello"}, {type: "DELIM", value: '!'}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "hello"}, {TYPE: "DELIM", value: '!'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@-text",
-    expected: [{type: "AT-KEYWORD", value: "-text"}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "-text"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@--abc",
-    expected: [{type: "AT-KEYWORD", value: "--abc"}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "--abc"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@--",
-    expected: [{type: "AT-KEYWORD", value: "--"}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "--"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@--11",
-    expected: [{type: "AT-KEYWORD", value: "--11"}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "--11"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@---",
-    expected: [{type: "AT-KEYWORD", value: "---"}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "---"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@\\ ",
-    expected: [{type: "AT-KEYWORD", value: " "}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: " "}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@-\\ ",
-    expected: [{type: "AT-KEYWORD", value: "- "}, {type: "EOF"}],
+    expected: [{TYPE: "AT-KEYWORD", value: "- "}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@@",
-    expected: [{type: "DELIM", value: '@'}, {type: "DELIM", value: '@'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '@'}, {TYPE: "DELIM", value: '@'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@2",
-    expected: [{type: "DELIM", value: '@'}, {type: "NUMBER", value: 2, isInteger: true}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '@'}, {TYPE: "NUMBER", value: 2, type: "integer"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "@-1",
-    expected: [{type: "DELIM", value: '@'}, {type: "NUMBER", value: -1, isInteger: true, sign: "-"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '@'}, {TYPE: "NUMBER", value: -1, type: "integer", sign: "-"}, {TYPE: "EOF"}],
   },
 
   // -- UrlToken
   {
     parser: "",
     css: "url(foo.gif)",
-    expected: [{type: "URL", value: "foo.gif"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "foo.gif"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "urL(https://example.com/cats.png)",
-    expected: [{type: "URL", value: "https://example.com/cats.png"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "https://example.com/cats.png"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "uRl(what-a.crazy^URL~this\\ is!)",
-    expected: [{type: "URL", value: "what-a.crazy^URL~this is!"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "what-a.crazy^URL~this is!"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "uRL(123#test)",
-    expected: [{type: "URL", value: "123#test"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "123#test"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "Url(escapes\\ \\\"\\'\\)\\()",
-    expected: [{type: "URL", value: "escapes \"')("}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "escapes \"')("}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "UrL(   whitespace   )",
-    expected: [{type: "URL", value: "whitespace"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "whitespace"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "URl( whitespace-eof ",
-    expected: [{type: "URL", value: "whitespace-eof"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "whitespace-eof"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "URL(eof",
-    expected: [{type: "URL", value: "eof"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "eof"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "url(not/*a*/comment)",
-    expected: [{type: "URL", value: "not/*a*/comment"}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: "not/*a*/comment"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "urL()",
-    expected: [{type: "URL", value: ""}, {type: "EOF"}],
+    expected: [{TYPE: "URL", value: ""}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "uRl(white space),",
-    expected: [{type: "BADURL"}, {type: "COMMA"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "COMMA"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "Url(b(ad),",
-    expected: [{type: "BADURL"}, {type: "COMMA"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "COMMA"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "uRl(ba'd):",
-    expected: [{type: "BADURL"}, {type: "COLON"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "COLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "urL(b\"ad):",
-    expected: [{type: "BADURL"}, {type: "COLON"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "COLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "uRl(b\"ad):",
-    expected: [{type: "BADURL"}, {type: "COLON"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "COLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "Url(b\\\rad):",
-    expected: [{type: "BADURL"}, {type: "COLON"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "COLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "url(b\\\nad):",
-    expected: [{type: "BADURL"}, {type: "COLON"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "COLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "url(/*'bad')*/",
-    expected: [{type: "BADURL"}, {type: "DELIM", value: '*'}, {type: "DELIM", value: '/'}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "DELIM", value: '*'}, {TYPE: "DELIM", value: '/'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "url(ba'd\\))",
-    expected: [{type: "BADURL"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "url(ba'd\\\\))",
-    expected: [{type: "BADURL"}, {type: "CLOSE-PAREN"}, {type: "EOF"}],
+    expected: [{TYPE: "BADURL"}, {TYPE: "CLOSE-PAREN"}, {TYPE: "EOF"}],
   },
 
   // -- StringToken
   {
     parser: "",
     css: "'text'",
-    expected: [{type: "STRING", value: "text"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "text"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\"text\"",
-    expected: [{type: "STRING", value: "text"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "text"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'testing, 123!'",
-    expected: [{type: "STRING", value: "testing, 123!"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "testing, 123!"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'es\\'ca\\\"pe'",
-    expected: [{type: "STRING", value: "es'ca\"pe"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "es'ca\"pe"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'\"quotes\"'",
-    expected: [{type: "STRING", value: "\"quotes\""}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "\"quotes\""}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\"'quotes'\"",
-    expected: [{type: "STRING", value: "'quotes'"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "'quotes'"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\"mismatch'",
-    expected: [{type: "STRING", value: "mismatch'"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "mismatch'"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'text\x05\t\x13'",
-    expected: [{type: "STRING", value: "text\x05\t\x13"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "text\x05\t\x13"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\"end on eof",
-    expected: [{type: "STRING", value: "end on eof"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "end on eof"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'esca\\\nped'",
-    expected: [{type: "STRING", value: "escaped"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "escaped"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\"esc\\\faped\"",
-    expected: [{type: "STRING", value: "escaped"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "escaped"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'new\\\rline'",
-    expected: [{type: "STRING", value: "newline"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "newline"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "\"new\\\r\nline\"",
-    expected: [{type: "STRING", value: "newline"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "newline"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'bad\nstring",
-    expected: [{type: "BADSTRING"}, {type: "WHITESPACE"}, {type: "IDENT", value: "string"}, {type: "EOF"}],
+    expected: [{TYPE: "BADSTRING"}, {TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "string"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'bad\rstring",
-    expected: [{type: "BADSTRING"}, {type: "WHITESPACE"}, {type: "IDENT", value: "string"}, {type: "EOF"}],
+    expected: [{TYPE: "BADSTRING"}, {TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "string"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'bad\r\nstring",
-    expected: [{type: "BADSTRING"}, {type: "WHITESPACE"}, {type: "IDENT", value: "string"}, {type: "EOF"}],
+    expected: [{TYPE: "BADSTRING"}, {TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "string"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'bad\fstring",
-    expected: [{type: "BADSTRING"}, {type: "WHITESPACE"}, {type: "IDENT", value: "string"}, {type: "EOF"}],
+    expected: [{TYPE: "BADSTRING"}, {TYPE: "WHITESPACE"}, {TYPE: "IDENT", value: "string"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'\0'",
-    expected: [{type: "STRING", value: "\uFFFD"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "\uFFFD"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'hel\0lo'",
-    expected: [{type: "STRING", value: "hel\uFFFDlo"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "hel\uFFFDlo"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "'h\\65l\0lo'",
-    expected: [{type: "STRING", value: "hel\uFFFDlo"}, {type: "EOF"}],
+    expected: [{TYPE: "STRING", value: "hel\uFFFDlo"}, {TYPE: "EOF"}],
   },
 
   // -- HashToken
   {
     parser: "",
     css: "#id-selector",
-    expected: [{type: "HASH", value: "id-selector", isIdent: true}, {type: "EOF"}],
+    expected: [{TYPE: "HASH", value: "id-selector", type: "id"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "#FF7700",
-    expected: [{type: "HASH", value: "FF7700", isIdent: true}, {type: "EOF"}],
+    expected: [{TYPE: "HASH", value: "FF7700", type: "id"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "#3377FF",
-    expected: [{type: "HASH", value: "3377FF", isIdent: false}, {type: "EOF"}],
+    expected: [{TYPE: "HASH", value: "3377FF", type: "unrestricted"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "#\\ ",
-    expected: [{type: "HASH", value: " ", isIdent: true}, {type: "EOF"}],
+    expected: [{TYPE: "HASH", value: " ", type: "id"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "# ",
-    expected: [{type: "DELIM", value: '#'}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '#'}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "#\\\n",
-    expected: [{type: "DELIM", value: '#'}, {type: "DELIM", value: '\\'}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '#'}, {TYPE: "DELIM", value: '\\'}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "#\\\r\n",
-    expected: [{type: "DELIM", value: '#'}, {type: "DELIM", value: '\\'}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '#'}, {TYPE: "DELIM", value: '\\'}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "#!",
-    expected: [{type: "DELIM", value: '#'}, {type: "DELIM", value: '!'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '#'}, {TYPE: "DELIM", value: '!'}, {TYPE: "EOF"}],
   },
 
   // -- NumberToken
   {
     parser: "",
     css: "10",
-    expected: [{type: "NUMBER", value: 10, isInteger: true}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 10, type: "integer"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "12.0",
-    expected: [{type: "NUMBER", value: 12, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 12, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "+45.6",
-    expected: [{type: "NUMBER", value: 45.6, isInteger: false, sign: "+"}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 45.6, type: "number", sign: "+"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-7",
-    expected: [{type: "NUMBER", value: -7, isInteger: true, sign: "-"}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: -7, type: "integer", sign: "-"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "010",
-    expected: [{type: "NUMBER", value: 10, isInteger: true}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 10, type: "integer"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "10e0",
-    expected: [{type: "NUMBER", value: 10, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 10, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "12e3",
-    expected: [{type: "NUMBER", value: 12000, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 12000, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "3e+1",
-    expected: [{type: "NUMBER", value: 30, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 30, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "12E-1",
-    expected: [{type: "NUMBER", value: 1.2, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 1.2, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ".7",
-    expected: [{type: "NUMBER", value: 0.7, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 0.7, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-.3",
-    expected: [{type: "NUMBER", value: -0.3, isInteger: false, sign: "-"}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: -0.3, type: "number", sign: "-"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "+637.54e-2",
-    expected: [{type: "NUMBER", value: 6.3754, isInteger: false, sign: "+"}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 6.3754, type: "number", sign: "+"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-12.34E+2",
-    expected: [{type: "NUMBER", value: -1234, isInteger: false, sign: "-"}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: -1234, type: "number", sign: "-"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "+ 5",
-    expected: [{type: "DELIM", value: '+'}, {type: "WHITESPACE"}, {type: "NUMBER", value: 5, isInteger: true}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '+'}, {TYPE: "WHITESPACE"}, {TYPE: "NUMBER", value: 5, type: "integer"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-+12",
-    expected: [{type: "DELIM", value: '-'}, {type: "NUMBER", value: 12, isInteger: true, sign: "+"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '-'}, {TYPE: "NUMBER", value: 12, type: "integer", sign: "+"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "+-21",
-    expected: [{type: "DELIM", value: '+'}, {type: "NUMBER", value: -21, isInteger: true, sign: "-"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '+'}, {TYPE: "NUMBER", value: -21, type: "integer", sign: "-"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "++22",
-    expected: [{type: "DELIM", value: '+'}, {type: "NUMBER", value: 22, isInteger: true, sign: "+"}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '+'}, {TYPE: "NUMBER", value: 22, type: "integer", sign: "+"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "13.",
-    expected: [{type: "NUMBER", value: 13, isInteger: true}, {type: "DELIM", value: '.'}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 13, type: "integer"}, {TYPE: "DELIM", value: '.'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "1.e2",
-    expected: [{type: "NUMBER", value: 1, isInteger: true}, {type: "DELIM", value: '.'}, {type: "IDENT", value: "e2"}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 1, type: "integer"}, {TYPE: "DELIM", value: '.'}, {TYPE: "IDENT", value: "e2"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "2e3.5",
-    expected: [{type: "NUMBER", value: 2000, isInteger: false}, {type: "NUMBER", value: 0.5, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 2000, type: "number"}, {TYPE: "NUMBER", value: 0.5, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "2e3.",
-    expected: [{type: "NUMBER", value: 2000, isInteger: false}, {type: "DELIM", value: '.'}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 2000, type: "number"}, {TYPE: "DELIM", value: '.'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "1000000000000000000000000",
-    expected: [{type: "NUMBER", value: 1e24, isInteger: true}, {type: "EOF"}],
+    expected: [{TYPE: "NUMBER", value: 1e24, type: "integer"}, {TYPE: "EOF"}],
   },
 
   // -- DimensionToken
   {
     parser: "",
     css: "10px",
-    expected: [{type: "DIMENSION", value: 10, isInteger: true, unit: "px"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 10, type: "integer", unit: "px"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "12.0em",
-    expected: [{type: "DIMENSION", value: 12, isInteger: false, unit: "em"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 12, type: "number", unit: "em"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-12.0em",
-    expected: [{type: "DIMENSION", value: -12, isInteger: false, unit: "em", sign: "-"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: -12, type: "number", unit: "em", sign: "-"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "+45.6__qem",
-    expected: [{type: "DIMENSION", value: 45.6, isInteger: false, unit: "__qem", sign: "+"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 45.6, type: "number", unit: "__qem", sign: "+"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "5e",
-    expected: [{type: "DIMENSION", value: 5, isInteger: true, unit: "e"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 5, type: "integer", unit: "e"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "5px-2px",
-    expected: [{type: "DIMENSION", value: 5, isInteger: true, unit: "px-2px"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 5, type: "integer", unit: "px-2px"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "5e-",
-    expected: [{type: "DIMENSION", value: 5, isInteger: true, unit: "e-"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 5, type: "integer", unit: "e-"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "5\\ ",
-    expected: [{type: "DIMENSION", value: 5, isInteger: true, unit: " "}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 5, type: "integer", unit: " "}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "40\\70\\78",
-    expected: [{type: "DIMENSION", value: 40, isInteger: true, unit: "px"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 40, type: "integer", unit: "px"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "4e3e2",
-    expected: [{type: "DIMENSION", value: 4000, isInteger: false, unit: "e2"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 4000, type: "number", unit: "e2"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "0x10px",
-    expected: [{type: "DIMENSION", value: 0, isInteger: true, unit: "x10px"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 0, type: "integer", unit: "x10px"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "4unit ",
-    expected: [{type: "DIMENSION", value: 4, isInteger: true, unit: "unit"}, {type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 4, type: "integer", unit: "unit"}, {TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "5e+",
-    expected: [{type: "DIMENSION", value: 5, isInteger: true, unit: "e"}, {type: "DELIM", value: '+'}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 5, type: "integer", unit: "e"}, {TYPE: "DELIM", value: '+'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "2e.5",
-    expected: [{type: "DIMENSION", value: 2, isInteger: true, unit: "e"}, {type: "NUMBER", value: 0.5, isInteger: false}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 2, type: "integer", unit: "e"}, {TYPE: "NUMBER", value: 0.5, type: "number"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "2e+.5",
-    expected: [{type: "DIMENSION", value: 2, isInteger: true, unit: "e"}, {type: "NUMBER", value: 0.5, isInteger: false, sign: "+"}, {type: "EOF"}],
+    expected: [{TYPE: "DIMENSION", value: 2, type: "integer", unit: "e"}, {TYPE: "NUMBER", value: 0.5, type: "number", sign: "+"}, {TYPE: "EOF"}],
   },
 
   // -- PercentageToken
   {
     parser: "",
     css: "10%",
-    expected: [{type: "PERCENTAGE", value: 10}, {type: "EOF"}],
+    expected: [{TYPE: "PERCENTAGE", value: 10}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "+12.0%",
-    expected: [{type: "PERCENTAGE", value: 12, sign: "+"}, {type: "EOF"}],
+    expected: [{TYPE: "PERCENTAGE", value: 12, sign: "+"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "-48.99%",
-    expected: [{type: "PERCENTAGE", value: -48.99, sign: "-"}, {type: "EOF"}],
+    expected: [{TYPE: "PERCENTAGE", value: -48.99, sign: "-"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "6e-1%",
-    expected: [{type: "PERCENTAGE", value: 0.6}, {type: "EOF"}],
+    expected: [{TYPE: "PERCENTAGE", value: 0.6}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "5%%",
-    expected: [{type: "PERCENTAGE", value: 5}, {type: "DELIM", value: '%'}, {type: "EOF"}],
+    expected: [{TYPE: "PERCENTAGE", value: 5}, {TYPE: "DELIM", value: '%'}, {TYPE: "EOF"}],
   },
 
   // -- UnicodeRangeToken
@@ -1057,203 +1057,203 @@ var TESTS = [
     parser: "",
     css: "u+012345-123456",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "NUMBER", value: 12345, isInteger: true, sign: "+"},
-      {type: "NUMBER", value: -123456, isInteger: true, sign: "-"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "NUMBER", value: 12345, type: "integer", sign: "+"},
+      {TYPE: "NUMBER", value: -123456, type: "integer", sign: "-"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "U+1234-2345",
     expected: [
-      {type: "IDENT", value: "U"},
-      {type: "NUMBER", value: 1234, isInteger: true, sign: "+"},
-      {type: "NUMBER", value: -2345, isInteger: true, sign: "-"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "U"},
+      {TYPE: "NUMBER", value: 1234, type: "integer", sign: "+"},
+      {TYPE: "NUMBER", value: -2345, type: "integer", sign: "-"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+222-111",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "NUMBER", value: 222, isInteger: true, sign: "+"},
-      {type: "NUMBER", value: -111, isInteger: true, sign: "-"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "NUMBER", value: 222, type: "integer", sign: "+"},
+      {TYPE: "NUMBER", value: -111, type: "integer", sign: "-"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "U+CafE-d00D",
     expected: [
-      {type: "IDENT", value: "U"},
-      {type: "DELIM", value: "+"},
-      {type: "IDENT", value: "CafE-d00D"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "U"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "IDENT", value: "CafE-d00D"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "U+2??",
     expected: [
-      {type: "IDENT", value: "U"},
-      {type: "NUMBER", value: 2, isInteger: true, sign: "+"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "U"},
+      {TYPE: "NUMBER", value: 2, type: "integer", sign: "+"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "U+ab12??",
     expected: [
-      {type: "IDENT", value: "U"},
-      {type: "DELIM", value: "+"},
-      {type: "IDENT", value: "ab12"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "U"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "IDENT", value: "ab12"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+??????",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DELIM", value: "+"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+??",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DELIM", value: "+"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+222+111",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "NUMBER", value: 222, isInteger: true, sign: "+"},
-      {type: "NUMBER", value: 111, isInteger: true, sign: "+"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "NUMBER", value: 222, type: "integer", sign: "+"},
+      {TYPE: "NUMBER", value: 111, type: "integer", sign: "+"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+12345678",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "NUMBER", value: 12345678, isInteger: true, sign: "+"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "NUMBER", value: 12345678, type: "integer", sign: "+"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+123-12345678",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "NUMBER", value: 123, isInteger: true, sign: "+"},
-      {type: "NUMBER", value: -12345678, isInteger: true, sign: "-"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "NUMBER", value: 123, type: "integer", sign: "+"},
+      {TYPE: "NUMBER", value: -12345678, type: "integer", sign: "-"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+cake",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DELIM", value: "+"},
-      {type: "IDENT", value: "cake"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "IDENT", value: "cake"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+1234-gggg",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DIMENSION", value: 1234, isInteger: true, unit: "-gggg", sign: "+"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DIMENSION", value: 1234, type: "integer", unit: "-gggg", sign: "+"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "U+ab12???",
     expected: [
-      {type: "IDENT", value: "U"},
-      {type: "DELIM", value: "+"},
-      {type: "IDENT", value: "ab12"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "U"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "IDENT", value: "ab12"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+a1?-123",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DELIM", value: "+"},
-      {type: "IDENT", value: "a1"},
-      {type: "DELIM", value: "?"},
-      {type: "NUMBER", value: -123, isInteger: true, sign: "-"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "IDENT", value: "a1"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "NUMBER", value: -123, type: "integer", sign: "-"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+1??4",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "NUMBER", value: 1, isInteger: true, sign: "+"},
-      {type: "DELIM", value: "?"},
-      {type: "DELIM", value: "?"},
-      {type: "NUMBER", value: 4, isInteger: true},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "NUMBER", value: 1, type: "integer", sign: "+"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "DELIM", value: "?"},
+      {TYPE: "NUMBER", value: 4, type: "integer"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+z",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DELIM", value: "+"},
-      {type: "IDENT", value: "z"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "IDENT", value: "z"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DELIM", value: "+"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "EOF"},
     ],
   },
   {
     parser: "",
     css: "u+-543",
     expected: [
-      {type: "IDENT", value: "u"},
-      {type: "DELIM", value: "+"},
-      {type: "NUMBER", value: -543, isInteger: true, sign: "-"},
-      {type: "EOF"},
+      {TYPE: "IDENT", value: "u"},
+      {TYPE: "DELIM", value: "+"},
+      {TYPE: "NUMBER", value: -543, type: "integer", sign: "-"},
+      {TYPE: "EOF"},
     ],
   },
 
@@ -1261,37 +1261,37 @@ var TESTS = [
   {
     parser: "",
     css: "/*comment*/a",
-    expected: [{type: "IDENT", value: "a"}, {type: "EOF"}],
+    expected: [{TYPE: "IDENT", value: "a"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "/**\\2f**//",
-    expected: [{type: "DELIM", value: '/'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '/'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "/**y*a*y**/ ",
-    expected: [{type: "WHITESPACE"}, {type: "EOF"}],
+    expected: [{TYPE: "WHITESPACE"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ",/* \n :) \n */)",
-    expected: [{type: "COMMA"}, {type: "CLOSE-PAREN"}, {type: "EOF"}],
+    expected: [{TYPE: "COMMA"}, {TYPE: "CLOSE-PAREN"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ":/*/*/",
-    expected: [{type: "COLON"}, {type: "EOF"}],
+    expected: [{TYPE: "COLON"}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: "/**/*",
-    expected: [{type: "DELIM", value: '*'}, {type: "EOF"}],
+    expected: [{TYPE: "DELIM", value: '*'}, {TYPE: "EOF"}],
   },
   {
     parser: "",
     css: ";/******",
-    expected: [{type: "SEMICOLON"}, {type: "EOF"}],
+    expected: [{TYPE: "SEMICOLON"}, {TYPE: "EOF"}],
   },
 
   // parseAStylesheet()
@@ -1300,26 +1300,26 @@ var TESTS = [
         bar: baz;
     }`,
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "QUALIFIED-RULE",
+          "TYPE": "QUALIFIED-RULE",
           "prelude": [
             {
-              "type": "IDENT",
+              "TYPE": "IDENT",
               "value": "foo"
             },
             {
-              "type": "WHITESPACE"
+              "TYPE": "WHITESPACE"
             }
           ],
           "declarations": [
             {
-              "type": "DECLARATION",
+              "TYPE": "DECLARATION",
               "name": "bar",
               "value": [
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "baz"
                 }
               ],
@@ -1334,54 +1334,54 @@ var TESTS = [
   {
     css: 'foo { bar: rgb(255, 0, 127); }',
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "QUALIFIED-RULE",
+          "TYPE": "QUALIFIED-RULE",
           "prelude": [
             {
-              "type": "IDENT",
+              "TYPE": "IDENT",
               "value": "foo"
             },
             {
-              "type": "WHITESPACE"
+              "TYPE": "WHITESPACE"
             }
           ],
           "declarations": [
             {
-              "type": "DECLARATION",
+              "TYPE": "DECLARATION",
               "name": "bar",
               "value": [
                 {
-                  "type": "FUNCTION",
+                  "TYPE": "FUNCTION",
                   "name": "rgb",
                   "value": [
                     {
-                      "type": "NUMBER",
+                      "TYPE": "NUMBER",
                       "value": 255,
-                      "isInteger": true,
+                      "type": "integer",
                     },
                     {
-                      "type": "COMMA"
+                      "TYPE": "COMMA"
                     },
                     {
-                      "type": "WHITESPACE"
+                      "TYPE": "WHITESPACE"
                     },
                     {
-                      "type": "NUMBER",
+                      "TYPE": "NUMBER",
                       "value": 0,
-                      "isInteger": true,
+                      "type": "integer",
                     },
                     {
-                      "type": "COMMA"
+                      "TYPE": "COMMA"
                     },
                     {
-                      "type": "WHITESPACE"
+                      "TYPE": "WHITESPACE"
                     },
                     {
-                      "type": "NUMBER",
+                      "TYPE": "NUMBER",
                       "value": 127,
-                      "isInteger": true,
+                      "type": "integer",
                     }
                   ]
                 }
@@ -1397,18 +1397,18 @@ var TESTS = [
   {
     css: '#foo {}',
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "QUALIFIED-RULE",
+          "TYPE": "QUALIFIED-RULE",
           "prelude": [
             {
-              "type": "HASH",
+              "TYPE": "HASH",
               "value": "foo",
-              "isIdent": true
+              "type": "id"
             },
             {
-              "type": "WHITESPACE"
+              "TYPE": "WHITESPACE"
             }
           ],
           "declarations": [],
@@ -1420,10 +1420,10 @@ var TESTS = [
   {
     css: '@media{ }',
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "AT-RULE",
+          "TYPE": "AT-RULE",
           "name": "media",
           "prelude": [],
           "declarations": [],
@@ -1435,41 +1435,41 @@ var TESTS = [
   {
     css: '.foo {color: red; @media { foo: bar } color: green }',
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "QUALIFIED-RULE",
+          "TYPE": "QUALIFIED-RULE",
           "prelude": [
             {
-              "type": "DELIM",
+              "TYPE": "DELIM",
               "value": "."
             },
             {
-              "type": "IDENT",
+              "TYPE": "IDENT",
               "value": "foo"
             },
             {
-              "type": "WHITESPACE"
+              "TYPE": "WHITESPACE"
             }
           ],
           "declarations": [
             {
-              "type": "DECLARATION",
+              "TYPE": "DECLARATION",
               "name": "color",
               "value": [
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "red"
                 }
               ],
               "important": false
             },
             {
-              "type": "DECLARATION",
+              "TYPE": "DECLARATION",
               "name": "color",
               "value": [
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "green"
                 }
               ],
@@ -1478,20 +1478,20 @@ var TESTS = [
           ],
           "rules": [
             {
-              "type": "AT-RULE",
+              "TYPE": "AT-RULE",
               "name": "media",
               "prelude": [
                 {
-                  "type": "WHITESPACE"
+                  "TYPE": "WHITESPACE"
                 }
               ],
               "declarations": [
                 {
-                  "type": "DECLARATION",
+                  "TYPE": "DECLARATION",
                   "name": "foo",
                   "value": [
                     {
-                      "type": "IDENT",
+                      "TYPE": "IDENT",
                       "value": "bar"
                     }
                   ],
@@ -1508,23 +1508,23 @@ var TESTS = [
   {
     css: 'foo{div:hover; color:red{};}',
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "QUALIFIED-RULE",
+          "TYPE": "QUALIFIED-RULE",
           "prelude": [
             {
-              "type": "IDENT",
+              "TYPE": "IDENT",
               "value": "foo"
             }
           ],
           "declarations": [
             {
-              "type": "DECLARATION",
+              "TYPE": "DECLARATION",
               "name": "div",
               "value": [
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "hover"
                 }
               ],
@@ -1533,17 +1533,17 @@ var TESTS = [
           ],
           "rules": [
             {
-              "type": "QUALIFIED-RULE",
+              "TYPE": "QUALIFIED-RULE",
               "prelude": [
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "color"
                 },
                 {
-                  "type": "COLON"
+                  "TYPE": "COLON"
                 },
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "red"
                 }
               ],
@@ -1558,10 +1558,10 @@ var TESTS = [
   {
     css: `@foo;;foo {}`,
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "AT-RULE",
+          "TYPE": "AT-RULE",
           "name": "foo",
           "prelude": [],
           "declarations": null,
@@ -1573,34 +1573,34 @@ var TESTS = [
   {
     css: `foo{@foo;;foo {}}`,
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "QUALIFIED-RULE",
+          "TYPE": "QUALIFIED-RULE",
           "prelude": [
             {
-              "type": "IDENT",
+              "TYPE": "IDENT",
               "value": "foo"
             }
           ],
           "declarations": [],
           "rules": [
             {
-              "type": "AT-RULE",
+              "TYPE": "AT-RULE",
               "name": "foo",
               "prelude": [],
               "declarations": null,
               "rules": null
             },
             {
-              "type": "QUALIFIED-RULE",
+              "TYPE": "QUALIFIED-RULE",
               "prelude": [
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "foo"
                 },
                 {
-                  "type": "WHITESPACE"
+                  "TYPE": "WHITESPACE"
                 }
               ],
               "declarations": [],
@@ -1614,30 +1614,30 @@ var TESTS = [
   {
     css: `foo { --div:hover{}}`,
     expected: {
-      "type": "STYLESHEET",
+      "TYPE": "STYLESHEET",
       "rules": [
         {
-          "type": "QUALIFIED-RULE",
+          "TYPE": "QUALIFIED-RULE",
           "prelude": [
             {
-              "type": "IDENT",
+              "TYPE": "IDENT",
               "value": "foo"
             },
             {
-              "type": "WHITESPACE"
+              "TYPE": "WHITESPACE"
             }
           ],
           "declarations": [
             {
-              "type": "DECLARATION",
+              "TYPE": "DECLARATION",
               "name": "--div",
               "value": [
                 {
-                  "type": "IDENT",
+                  "TYPE": "IDENT",
                   "value": "hover"
                 },
                 {
-                  "type": "BLOCK",
+                  "TYPE": "BLOCK",
                   "name": "{",
                   "value": []
                 }


### PR DESCRIPTION
The spec says `type` flag for some tokens, while this module outputs `isInteger`, `isIdent`, etc. instead, which is not consistent.

Unfortunately the `type` property is already used to determine the token/rule type. A simple workaround is to use `TYPE` instead, as this special property is mostly used for the JSON output (in other context we can simply check by `obj instanceof theTokenClass` or `obj.constructor.name === theTokenClass.name` instead).
